### PR TITLE
add field tag for deprecated fields

### DIFF
--- a/ref_test.go
+++ b/ref_test.go
@@ -43,6 +43,63 @@ func TestPointerStruct(t *testing.T) {
 	}
 }
 
+type M0D struct {
+	A *M1 `gobi:"deprecated"`
+	B *M1
+	X *int
+	Y *int
+}
+
+type M0D0 struct {
+	B *M1
+	X *int
+	Y *int
+}
+
+func TestPointerStructDeprecatedField(t *testing.T) {
+	var t0 M0D
+	i := 777
+	t0.A = &M1{SomeInt: 9999}
+	t0.B = t0.A
+	t0.X = &i
+	t0.Y = &i
+	b := new(bytes.Buffer)
+	NewEncoder(b).Encode(t0)
+	var t1 M0D
+	err := NewDecoder(b).Decode(&t1)
+	if err != nil {
+		t.Fatal("error: ", err)
+	}
+	if t1.X != t1.Y {
+		t.Fatal("should be equal")
+	}
+	if t1.A != nil {
+		t.Fatal("should be nil")
+	}
+	if t1.B == nil {
+		t.Fatal("should not be nil")
+	}
+	if t1.B.SomeInt != 9999 {
+		t.Fatal("ref error")
+	}
+	b = new(bytes.Buffer)
+	NewEncoder(b).Encode(t1)
+	var t2 M0D0
+	err = NewDecoder(b).Decode(&t2)
+	if err != nil {
+		t.Fatal("error: ", err)
+	}
+	if t2.X != t2.Y {
+		t.Fatal("should be equal")
+	}
+	if t2.B == nil {
+		t.Fatal("should not be nil")
+	}
+	if t2.B.SomeInt != 9999 {
+		t.Fatal("ref error")
+	}
+}
+
 type PointerArray struct {
 	Array []*M1
 }

--- a/type.go
+++ b/type.go
@@ -16,6 +16,11 @@ import (
 	"unicode/utf8"
 )
 
+const (
+	tagName       = "gobi"
+	tagDeprecated = "deprecated"
+)
+
 // userTypeInfo stores the information associated with a type the user has handed
 // to the package.  It's computed once and stored in a map keyed by reflection
 // type.
@@ -563,6 +568,15 @@ func newTypeObject(name string, ut *userTypeInfo, rt reflect.Type) (gobType, err
 	}
 }
 
+// isDeprecated reports whether this is a deprecated field, and thus should
+// not be included during encoding.
+func isDeprecated(field *reflect.StructField) bool {
+	if t, ok := field.Tag.Lookup(tagName); ok {
+		return t == tagDeprecated
+	}
+	return false
+}
+
 // isExported reports whether this is an exported - upper case - name.
 func isExported(name string) bool {
 	rune, _ := utf8.DecodeRuneInString(name)
@@ -573,7 +587,7 @@ func isExported(name string) bool {
 // It will be transmitted only if it is exported and not a chan or func field
 // or pointer to chan or func.
 func isSent(field *reflect.StructField) bool {
-	if !isExported(field.Name) {
+	if !isExported(field.Name) || isDeprecated(field) {
 		return false
 	}
 	// If the field is a chan or func or pointer thereto, don't send it.


### PR DESCRIPTION
As it's not possible remove pointer fields due to the way they are encoded, a workaround is to first deprecate the fields so they won't be included during encoding.